### PR TITLE
Removed the restriction against using dev-master.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
             "email": "lockhartbradley92@gmail.com"
         }
     ],
-    "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
             "bradlockhart\\laravuewind\\": "src/"


### PR DESCRIPTION
Packages / libraries / etc. should not enforce minimum-stability on themselves or adopters will be unable to checkout dev-master.

Through my work with the Bettergist Collector, this project is only one of 7 out of 9,639 composer packages with a vendor starting with the lettter `b` to have this type of composer.json bug.